### PR TITLE
re-enable option --http-reconnect

### DIFF
--- a/QmlVlcConfig.cpp
+++ b/QmlVlcConfig.cpp
@@ -141,7 +141,7 @@ libvlc_instance_t* QmlVlcConfig::createLibvlcInstance()
 
     QVector<const char*> opts;
 
-    //opts.push_back( "--http-reconnect" );
+    opts.push_back( "--http-reconnect" );
 
     QByteArray networkCachingBuf;
     if( _networkCacheTime >= 0 ) {


### PR DESCRIPTION
the failure of this options previously seems to have been caused by the a missing plugin or inability of the binaries to find a dependent plugin